### PR TITLE
chore: データ自動更新を PR 経由に変更し Git ワークフローを整備

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   scrape:
@@ -44,16 +45,15 @@ jobs:
         working-directory: pipeline
         run: npm run scrape:finance
 
-      - name: Check for changes
-        id: changes
-        run: |
-          git diff --quiet data/ && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: data/
+          commit-message: "chore: データ自動更新 ${{ github.run_id }}"
+          branch: auto/data-update
+          title: "chore: データ自動更新"
+          body: |
+            GitHub Actions による定期データ収集の結果です。
 
-      - name: Commit and push
-        if: steps.changes.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/
-          git commit -m "chore: データ自動更新 $(date -u +%Y-%m-%d)"
-          git push
+            自動生成されたPRです。内容を確認のうえマージしてください。
+          labels: automated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,18 @@ hsmch/kiryu-public-log/
 - **テーマ別**: 継続的なトピックの経緯まとめ
 - **about**: サイトの趣旨・中立性の方針・運営者情報
 
+## Git ワークフロー
+
+- **main**: 本番ブランチ。直接 push しない。変更は必ず PR 経由でマージする
+- **feature/xxx**: main から作成する作業ブランチ。PR で main にマージ
+- **auto/data-update**: GitHub Actions がデータ更新 PR を自動作成するブランチ
+
+### ブランチ命名規則
+
+- `feature/xxx` — 新機能・改善
+- `fix/xxx` — バグ修正
+- `auto/xxx` — GitHub Actions 自動生成
+
 ## 運用コスト見積もり
 
 - ホスティング（Cloudflare Pages）: 無料

--- a/README.md
+++ b/README.md
@@ -42,7 +42,21 @@ npm run dev
 # データ収集パイプラインの実行
 cd pipeline
 npm install
-npm run collect
+npm run scrape:members
+npm run scrape:sessions
+npm run scrape:updates
+npm run scrape:questions
+npm run scrape:finance
+```
+
+### Git Workflow
+
+main への直接 push は行わず、feature ブランチから PR を作成してマージします。
+データの定期収集も GitHub Actions が PR を自動作成します。
+
+```
+main ← PR ← feature/xxx   （手動の開発）
+main ← PR ← auto/data-update （GitHub Actions による自動データ更新）
 ```
 
 ## Data Sources


### PR DESCRIPTION
## Summary
- GitHub Actions のデータ自動更新を main 直接 push から PR 自動作成に変更（`peter-evans/create-pull-request`）
- CLAUDE.md に Git ワークフロー（ブランチ戦略・命名規則）を追記
- README.md に開発フローの説明を追記

## 変更ファイル
- `.github/workflows/collect.yml` — PR 作成方式に切り替え
- `CLAUDE.md` — Git ワークフローセクション追加
- `README.md` — Development セクション更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)