### PR TITLE
feat: CI ワークフローに未登録スクレイパーを追加

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -45,6 +45,22 @@ jobs:
         working-directory: pipeline
         run: npm run scrape:finance
 
+      - name: Scrape voting records
+        working-directory: pipeline
+        run: npm run scrape:voting
+
+      - name: Scrape schedule
+        working-directory: pipeline
+        run: npm run scrape:schedule
+
+      - name: Scrape population
+        working-directory: pipeline
+        run: npm run scrape:population
+
+      - name: Generate tags
+        working-directory: pipeline
+        run: npm run generate:tags
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/pipeline/src/scrape-voting-records.ts
+++ b/pipeline/src/scrape-voting-records.ts
@@ -1,4 +1,10 @@
-import { readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  readdirSync,
+  existsSync,
+} from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -165,8 +171,16 @@ async function main() {
   let successCount = 0;
   let errorCount = 0;
 
+  let skipCount = 0;
+
   for (const entry of sessionsWithPdf) {
     const filePath = resolve(OUTPUT_DIR, `${entry.slug}.json`);
+
+    if (existsSync(filePath)) {
+      log(`Skip ${entry.slug} (already exists)`);
+      skipCount++;
+      continue;
+    }
 
     log(`Processing: ${entry.session} (${entry.slug})`);
     await sleep(1000);
@@ -209,7 +223,9 @@ async function main() {
     successCount++;
   }
 
-  log(`Done: ${successCount} succeeded, ${errorCount} failed`);
+  log(
+    `Done: ${successCount} succeeded, ${errorCount} failed, ${skipCount} skipped`,
+  );
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

- `collect.yml` に未登録だった3つのスクレイパー（`scrape:voting`, `scrape:schedule`, `scrape:population`）と1つのジェネレーター（`generate:tags`）を追加
- `scrape:voting` は sessions のデータに依存するため `scrape:sessions` の後に配置、`generate:tags` は sessions と questions を参照するため最後に配置
- `scrape-voting-records.ts` に既存ファイルスキップロジックを追加し、`data/voting/{slug}.json` が既に存在するセッションはPDFダウンロード・パースをスキップするようにした（日次実行時の実行時間とサーバー負荷を削減）

## 変更ファイル

- `.github/workflows/collect.yml` — 4ステップ追加
- `pipeline/src/scrape-voting-records.ts` — `existsSync` による既存ファイルスキップ処理を追加

## 実行順序

```
scrape:members    → scrape:sessions   → scrape:updates    →
scrape:questions  → scrape:finance    → scrape:voting     →
scrape:schedule   → scrape:population → generate:tags     →
Create Pull Request
```

## Test plan

- [ ] `workflow_dispatch` で手動トリガーし全ステップが正常完了することを確認
- [ ] 2回目の実行で voting スクレイパーが既存ファイルをスキップすることを確認
- [ ] 生成された data PR に全データファイルの変更が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)