### PR TITLE
feat: OGP・SEO メタタグを追加

### DIFF
--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -4,12 +4,18 @@ import '../styles/global.css';
 interface Props {
   title?: string;
   description?: string;
+  path?: string;
 }
+
+const SITE_URL = 'https://kiryu.co';
 
 const {
   title = 'Kiryu Public Log',
   description = '桐生市の市政・議会の公開情報をわかりやすく整理してお届けするアーカイブサイト',
+  path = '',
 } = Astro.props;
+
+const canonicalUrl = `${SITE_URL}${path}`;
 ---
 
 <!doctype html>
@@ -21,6 +27,22 @@ const {
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
     <title>{title}</title>
+
+    <!-- canonical -->
+    <link rel="canonical" href={canonicalUrl} />
+
+    <!-- OGP -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Kiryu Public Log" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:locale" content="ja_JP" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
   </head>
   <body class="min-h-screen bg-gray-50 text-gray-900 antialiased">
     <header class="border-b border-gray-200 bg-white">

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -4,7 +4,7 @@ import Layout from '../layouts/Layout.astro';
 export const prerender = true;
 ---
 
-<Layout title="このサイトについて - Kiryu Public Log">
+<Layout title="このサイトについて - Kiryu Public Log" description="Kiryu Public Log の運営方針・データの出典・技術情報について" path="/about">
   <div class="mx-auto max-w-3xl px-4 py-8">
     <h1 class="text-2xl font-bold text-gray-900">このサイトについて</h1>
 

--- a/site/src/pages/council/[slug].astro
+++ b/site/src/pages/council/[slug].astro
@@ -34,7 +34,7 @@ function voteColor(vote: string): string {
 }
 ---
 
-<Layout title={`${member.name} - Kiryu Public Log`}>
+<Layout title={`${member.name} - Kiryu Public Log`} description={`${member.name}（${member.faction}）の投票行動・一般質問 | 桐生市議会`} path={`/council/${slug}`}>
   <div class="mx-auto max-w-4xl px-4 py-8">
     <nav class="text-sm text-gray-500">
       <a href="/council" class="text-blue-600 hover:text-blue-800">議員一覧</a>

--- a/site/src/pages/council/index.astro
+++ b/site/src/pages/council/index.astro
@@ -10,7 +10,7 @@ const factions = [...new Set(members.map((m) => m.faction))].filter(Boolean).sor
 const committees = [...new Set(members.map((m) => m.committee))].filter(Boolean).sort();
 ---
 
-<Layout title="議員一覧 - Kiryu Public Log">
+<Layout title="議員一覧 - Kiryu Public Log" description="桐生市議会の議員一覧。会派・委員会・当選回数などの情報を掲載" path="/council">
   <div class="mx-auto max-w-4xl px-4 py-8">
     <h1 class="text-2xl font-bold text-gray-900">議員一覧</h1>
     <p class="mt-2 text-sm text-gray-500">

--- a/site/src/pages/finance.astro
+++ b/site/src/pages/finance.astro
@@ -32,7 +32,7 @@ const expenditureColors = ["#f97316","#fb923c","#fdba74","#fed7aa","#ea580c","#f
 ---
 
 
-<Layout title="まちの数字 - Kiryu Public Log">
+<Layout title="まちの数字 - Kiryu Public Log" description="桐生市の人口・財政・予算に関する公開データをわかりやすく可視化" path="/finance">
   <div class="mx-auto max-w-4xl px-4 py-8">
     <h1 class="text-2xl font-bold text-gray-900">まちの数字</h1>
     <p class="mt-2 text-sm text-gray-500">桐生市の人口・財政に関する公開データ</p>

--- a/site/src/pages/guide.astro
+++ b/site/src/pages/guide.astro
@@ -4,7 +4,7 @@ import Layout from '../layouts/Layout.astro';
 export const prerender = true;
 ---
 
-<Layout title="議会の仕組みガイド - Kiryu Public Log">
+<Layout title="議会の仕組みガイド - Kiryu Public Log" description="桐生市議会の仕組み・定例会の流れ・用語集をわかりやすく解説" path="/guide">
   <div class="mx-auto max-w-3xl px-4 py-8">
     <nav class="text-sm text-gray-500">
       <a href="/about" class="text-blue-600 hover:text-blue-800">このサイトについて</a>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -15,7 +15,7 @@ const upcoming = getUpcomingEntries(5);
 const nextSession = upcoming.length > 0 ? upcoming[0].session : null;
 ---
 
-<Layout>
+<Layout path="/">
   <section class="mx-auto max-w-4xl px-4 py-16 sm:py-24">
     <div class="text-center">
       <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">

--- a/site/src/pages/schedule.astro
+++ b/site/src/pages/schedule.astro
@@ -35,7 +35,7 @@ function formatDate(date: string): string {
 }
 ---
 
-<Layout title="議会カレンダー - Kiryu Public Log">
+<Layout title="議会カレンダー - Kiryu Public Log" description="桐生市議会の本会議・委員会の日程一覧" path="/schedule">
   <div class="mx-auto max-w-4xl px-4 py-8">
     <h1 class="text-2xl font-bold text-gray-900">議会カレンダー</h1>
     <p class="mt-2 text-sm text-gray-500">

--- a/site/src/pages/sessions/[slug].astro
+++ b/site/src/pages/sessions/[slug].astro
@@ -55,7 +55,7 @@ function resultColor(result: string): string {
 }
 ---
 
-<Layout title={`${session.session} - Kiryu Public Log`}>
+<Layout title={`${session.session} - Kiryu Public Log`} description={`${session.session}の議案${session.bills.length}件の採決結果・一般質問 | 桐生市議会`} path={`/sessions/${slug}`}>
   <div class="mx-auto max-w-4xl px-4 py-8">
     <nav class="text-sm text-gray-500">
       <a href="/sessions" class="text-blue-600 hover:text-blue-800">議案・採決結果</a>

--- a/site/src/pages/sessions/index.astro
+++ b/site/src/pages/sessions/index.astro
@@ -34,7 +34,7 @@ function sessionNumLabel(slug: string): string {
 }
 ---
 
-<Layout title="議案・採決結果 - Kiryu Public Log">
+<Layout title="議案・採決結果 - Kiryu Public Log" description="桐生市議会の定例会・臨時会ごとの議案一覧と採決結果" path="/sessions">
   <div class="mx-auto max-w-4xl px-4 py-8">
     <h1 class="text-2xl font-bold text-gray-900">議案・採決結果</h1>
     <p class="mt-2 text-sm text-gray-500">

--- a/site/src/pages/topics/[tag].astro
+++ b/site/src/pages/topics/[tag].astro
@@ -37,7 +37,7 @@ const questionGroups = [...questionsBySession.entries()].sort((a, b) =>
 );
 ---
 
-<Layout title={`${tag} - テーマ別 - Kiryu Public Log`}>
+<Layout title={`${tag} - テーマ別 - Kiryu Public Log`} description={`桐生市議会における「${tag}」に関する議案・一般質問の一覧`} path={`/topics/${tag}`}>
   <div class="mx-auto max-w-4xl px-4 py-8">
     <nav class="text-sm text-gray-500">
       <a href="/topics" class="text-blue-600 hover:text-blue-800">テーマ別</a>

--- a/site/src/pages/topics/index.astro
+++ b/site/src/pages/topics/index.astro
@@ -8,7 +8,7 @@ const tagCounts = getTagCounts();
 const tags = getTags();
 ---
 
-<Layout title="テーマ別 - Kiryu Public Log">
+<Layout title="テーマ別 - Kiryu Public Log" description="桐生市議会の議案・一般質問をテーマごとに分類" path="/topics">
   <div class="mx-auto max-w-4xl px-4 py-8">
     <h1 class="text-2xl font-bold text-gray-900">テーマ別</h1>
     <p class="mt-2 text-sm text-gray-500">


### PR DESCRIPTION
## Summary

- Layout.astro に OGP メタタグ（og:type, og:site_name, og:title, og:description, og:url, og:locale）を追加
- Twitter Card メタタグ（twitter:card=summary, twitter:title, twitter:description）を追加
- canonical URL を全ページに設定
- 全12ページに `path` と `description` prop を設定し、ページ固有のメタ情報を出力
  - 議員ページ: 議員名と会派を含む description
  - 定例会ページ: 定例会名と議案件数を含む description
  - トピックページ: タグ名を含む description
  - 静的ページ（about, guide, finance, schedule, council一覧, sessions一覧, topics一覧, トップ）: 固有の description

## Not included

- `og:image` / `twitter:image`: デフォルト OG 画像がまだ未作成のため、今回は含めない（Phase 3 の別タスクで対応予定）

## Test plan

- [x] `npm run build` が成功すること
- [x] 生成された HTML に canonical, OGP, Twitter Card タグが含まれること
- [x] トップページの canonical URL が `https://kiryu.co/` であること
- [x] 議員ページの og:description に議員名と会派が含まれること
- [x] 定例会ページの og:description に定例会名と議案件数が含まれること
- [ ] デプロイ後、Facebook Sharing Debugger / Twitter Card Validator で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)