### PR TITLE
feat: Claude Code Action 導入

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,30 @@
+name: Claude Code Action
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issues' && github.event.label.name == 'claude') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Issue に `claude` ラベルを付けると Claude Code が自動で実装・PR作成するワークフローを追加
- Issue/PR コメントで `@claude` メンションでも発火
- タイムアウト30分、既存の `ANTHROPIC_API_KEY` を使用
- リポジトリに `claude` ラベル（紫）を作成済み

## Test plan
- [ ] main にマージ後、テスト用 Issue を作成して `claude` ラベルを付ける
- [ ] Actions タブでワークフローが発火することを確認
- [ ] Claude が PR を作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)