### PR TITLE
fix: Claude Code Action OIDC パーミッション追加

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -20,6 +20,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Claude Code Action が OIDC トークン取得に失敗していたため `id-token: write` パーミッションを追加
- エラー: `Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?`

## Test plan
- [ ] マージ後、Issue #23 に `claude` ラベルを再付与して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)