### PR TITLE
fix: Claude Code Action で PR 自動作成

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -29,3 +29,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Implement the changes described in the issue.
+            After making changes, always create a pull request using `gh pr create`.
+            The PR title should be concise and the body should reference the issue number with "Closes #<number>".


### PR DESCRIPTION
## Summary
- Claude Code Action に prompt を追加し、変更後に `gh pr create` で PR を自動作成するよう指示
- 以前はブランチ作成 + "Create PR" リンクの提示のみだった

## Test plan
- [ ] マージ後、新しい Issue に `claude` ラベルを付けて PR が自動作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)