### PR TITLE
fix: 人口推移データの誤りを修正、スクレイパーのカラム解析バグを修正

### DIFF
--- a/data/population.json
+++ b/data/population.json
@@ -10,127 +10,127 @@
   "history": [
     {
       "year": 1920,
-      "population": 20093,
+      "population": 37674,
       "households": 7162,
       "source": "国勢調査"
     },
     {
       "year": 1925,
-      "population": 22440,
+      "population": 42553,
       "households": 8374,
       "source": "国勢調査"
     },
     {
       "year": 1930,
-      "population": 27475,
+      "population": 52906,
       "households": 10255,
       "source": "国勢調査"
     },
     {
       "year": 1935,
-      "population": 40127,
+      "population": 76145,
       "households": 13478,
       "source": "国勢調査"
     },
     {
       "year": 1940,
-      "population": 46591,
+      "population": 86086,
       "households": 15819,
       "source": "国勢調査"
     },
     {
       "year": 1947,
-      "population": 48188,
+      "population": 91482,
       "households": 19309,
       "source": "国勢調査"
     },
     {
       "year": 1950,
-      "population": 50590,
+      "population": 95533,
       "households": 19524,
       "source": "国勢調査"
     },
     {
       "year": 1955,
-      "population": 62158,
+      "population": 116935,
       "households": 23647,
       "source": "国勢調査"
     },
     {
       "year": 1960,
-      "population": 65923,
+      "population": 123010,
       "households": 26870,
       "source": "国勢調査"
     },
     {
       "year": 1965,
-      "population": 67842,
+      "population": 127880,
       "households": 30674,
       "source": "国勢調査"
     },
     {
       "year": 1970,
-      "population": 69913,
+      "population": 133141,
       "households": 34534,
       "source": "国勢調査"
     },
     {
       "year": 1975,
-      "population": 69997,
+      "population": 134239,
       "households": 37112,
       "source": "国勢調査"
     },
     {
       "year": 1980,
-      "population": 69001,
+      "population": 132889,
       "households": 38755,
       "source": "国勢調査"
     },
     {
       "year": 1985,
-      "population": 68045,
+      "population": 131267,
       "households": 39903,
       "source": "国勢調査"
     },
     {
       "year": 1990,
-      "population": 65456,
+      "population": 126446,
       "households": 40968,
       "source": "国勢調査"
     },
     {
       "year": 1995,
-      "population": 62180,
+      "population": 120377,
       "households": 41496,
       "source": "国勢調査"
     },
     {
       "year": 2000,
-      "population": 59602,
+      "population": 115434,
       "households": 41868,
       "source": "国勢調査"
     },
     {
       "year": 2005,
-      "population": 66241,
+      "population": 128037,
       "households": 46647,
       "source": "国勢調査"
     },
     {
       "year": 2010,
-      "population": 62939,
+      "population": 121704,
       "households": 46688,
       "source": "国勢調査"
     },
     {
       "year": 2015,
-      "population": 59387,
+      "population": 114714,
       "households": 46034,
       "source": "国勢調査"
     },
     {
       "year": 2020,
-      "population": 55053,
+      "population": 106445,
       "households": 44971,
       "source": "国勢調査"
     }

--- a/pipeline/src/scrape-population.ts
+++ b/pipeline/src/scrape-population.ts
@@ -149,7 +149,8 @@ async function fetchHistoricalPopulation(): Promise<PopulationEntry[]> {
           let population: number;
           let households: number;
           if (cellTexts.length >= 5) {
-            population = parseNumber(cellTexts[3]!);
+            // Table format: [年次, 人口計, 男, 女, 世帯数]
+            population = parseNumber(cellTexts[1]!);
             households = parseNumber(cellTexts[4]!);
           } else if (cellTexts.length >= 3) {
             population = parseNumber(cellTexts[1]!);


### PR DESCRIPTION
Closes #23

スクレイパーが公式サイトの5列表から女性人口を人口合計と誤認していたバグを修正。

Generated with [Claude Code](https://claude.ai/code)