### PR TITLE
docs: README を現状のプロジェクト構成に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,39 @@
 Kiryu Public Log（KPL）は、桐生市が公開している議会・市政情報を収集・構造化し、市民が簡単にアクセスできる形で提供するプロジェクトです。
 
 - 議案・採決結果を一覧で確認
-- 議員の活動記録を横断的に閲覧
-- 予算・財政データの可視化
+- 議員ごとの投票履歴・活動記録を横断的に閲覧
+- 投票パターン分析（会派結束度・ヒートマップ）
+- 予算・財政データの可視化（経年比較・Chart.js）
+- 人口推移グラフ
+- テーマ別タイムライン
+- サイト内全文検索（pagefind）
 - すべての情報に公式ページへのリンクを併記
 
 ## Tech Stack
 
-- **Site**: [Astro](https://astro.build/)（静的サイト生成）
+- **Site**: [Astro](https://astro.build/)（静的サイト生成）+ Tailwind CSS
 - **Hosting**: Cloudflare Pages
-- **Data Collection**: Node.js / GitHub Actions
-- **Data Processing**: Claude API
+- **Data Collection**: TypeScript / [cheerio](https://cheerio.js.org/) / pdf-parse / xlsx
+- **Data Processing**: Claude API（タグ付け・分類）
+- **Data Validation**: [Zod](https://zod.dev/)（スキーマバリデーション）
+- **Charts**: Chart.js / SVG
+- **Search**: [pagefind](https://pagefind.app/)
+- **Testing**: [Playwright](https://playwright.dev/)（スモークテスト）
+- **CI/CD**: GitHub Actions
 - **Data Format**: JSON
 
 ## Project Structure
 
 ```
 ├── site/          # Astro サイト本体
+│   └── tests/     # Playwright スモークテスト
 ├── pipeline/      # データ収集パイプライン
+│   └── src/       # スクレイパー・バリデーション・スキーマ
 ├── data/          # 構造化データ (JSON)
-├── scripts/       # ユーティリティ
+│   ├── sessions/  # 定例会・臨時会（議案・採決結果）
+│   ├── voting/    # 議員別投票記録
+│   ├── questions/ # 一般質問通告
+│   └── finance/   # 予算・財政データ
 └── CLAUDE.md      # プロジェクトコンテキスト
 ```
 
@@ -39,21 +53,40 @@ cd site
 npm install
 npm run dev
 
-# データ収集パイプラインの実行
-cd pipeline
-npm install
-npm run scrape:members
-npm run scrape:sessions
-npm run scrape:updates
-npm run scrape:questions
-npm run scrape:finance
-npm run validate          # データ品質チェック
-
-# スモークテスト
-cd site
+# サイトのビルド & スモークテスト
 npm run build
 npx playwright test
 ```
+
+```bash
+# データ収集パイプライン
+cd pipeline
+npm install
+
+# 各スクレイパーの個別実行
+npm run scrape:members       # 議員名簿
+npm run scrape:sessions      # 議案・採決結果
+npm run scrape:voting        # 議員別投票記録
+npm run scrape:questions     # 一般質問通告
+npm run scrape:schedule      # 議会日程
+npm run scrape:population    # 人口データ
+npm run scrape:finance       # 基金残高
+npm run scrape:budget-history # 財政経年データ
+npm run scrape:updates       # 新着情報
+npm run generate:tags        # AI タグ付け (要 ANTHROPIC_API_KEY)
+npm run analyze:voting       # 投票パターン分析
+
+# データ品質チェック
+npm run validate
+```
+
+### CI/CD
+
+| ワークフロー | トリガー | 内容 |
+|---|---|---|
+| `collect.yml` | 毎日 6:00 JST | 全スクレイパー実行 → バリデーション → 自動 PR 作成 |
+| `ci.yml` | PR 作成時 | サイトビルド + スモークテスト / データバリデーション |
+| `deploy.yml` | main push 時 | サイトビルド → Cloudflare Pages デプロイ |
 
 ### Git Workflow
 
@@ -61,8 +94,8 @@ main への直接 push は行わず、feature ブランチから PR を作成し
 データの定期収集も GitHub Actions が PR を自動作成します。
 
 ```
-main ← PR ← feature/xxx   （手動の開発）
-main ← PR ← auto/data-update （GitHub Actions による自動データ更新）
+main ← PR ← feature/xxx        （手動の開発）
+main ← PR ← auto/data-update   （GitHub Actions による自動データ更新）
 ```
 
 ## Data Sources
@@ -70,6 +103,7 @@ main ← PR ← auto/data-update （GitHub Actions による自動データ更�
 - [桐生市議会](https://www.city.kiryu.lg.jp/shigikai/index.html)
 - [桐生市 財政状況](https://www.city.kiryu.lg.jp/shisei/zaisei/index.html)
 - [桐生市 統計情報](https://www.city.kiryu.lg.jp/shisei/1018369/index.html)
+- [群馬県 市町村財政状況資料集](https://www.pref.gunma.jp/page/6270.html)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Tech Stack: Zod, Playwright, pagefind, Chart.js, Tailwind CSS を追記
- Project Structure: 実態に合わせて更新（空の scripts/ を削除、サブディレクトリを追記）
- Development: 全スクレイパーコマンドを網羅
- CI/CD: collect.yml / ci.yml / deploy.yml の一覧表を追加
- Data Sources: 群馬県の財政データを追加
- About: 投票分析・テーマ別タイムライン・検索等の機能を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)